### PR TITLE
added missing dependencies icu and liblzma

### DIFF
--- a/recipe/igraph_test.py
+++ b/recipe/igraph_test.py
@@ -1,0 +1,3 @@
+import igraph.test
+
+igraph.test.run_tests()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,28 +12,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip : true  # [win or py34]
+  skip : true  # [win or py36]
 
 requirements:
   build:
+    - python
     - igraph 0.7.1
     - pkg-config
-    - python
     - setuptools
     - toolchain
-    - backports.lzma
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - icu 58.*
   run:
-    - igraph 0.7.1
     - python
-    - backports.lzma
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - igraph 0.7.1
+    - icu 58.*
 
 test:
   imports:
@@ -53,4 +47,3 @@ about:
 extra:
   recipe-maintainers:
     - sodre
-    - vgauthier

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip : true  # [win]
+  skip : true  # [win or py34]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,17 @@ requirements:
     - python
     - setuptools
     - toolchain
-
+    - backports.lzma
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
   run:
     - igraph 0.7.1
     - python
+    - backports.lzma
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,10 @@ test:
     - igraph.remote
     - igraph.test
     - igraph.vendor
+  files:
+    - igraph_test.py
+  require:
+    - python
 
 about:
   home: http://pypi.python.org/pypi/python-igraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - sodre
+    - vgauthier

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/env bash
+
+python igraph_test.py


### PR DESCRIPTION
I encountered an issue of missing while installing python-igraph on osx. So I changed in the meta.yaml the two missing dependencies:
- backports.lzma
- icu support 