### PR TITLE
Call run_tests from igraph.test during package build time

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
     - igraph.remote
     - igraph.test
     - igraph.vendor
+  commands:
+    - python -c 'from igraph.test import run_tests; run_tests()'
 
 about:
   home: http://pypi.python.org/pypi/python-igraph


### PR DESCRIPTION
Trying to replicate the OSX error in the build system.