### PR TITLE
Updated to 0.8.0.

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -6,11 +6,43 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '2.7'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -6,11 +6,43 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.6'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -6,11 +6,43 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.7'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/linux_python3.8.yaml
+++ b/.ci_support/linux_python3.8.yaml
@@ -6,11 +6,43 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.8'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -8,13 +8,45 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '2.7'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,13 +8,45 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.6'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -8,13 +8,45 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.7'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python3.8.yaml
+++ b/.ci_support/osx_python3.8.yaml
@@ -8,13 +8,45 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+gmp:
+- '6'
+icu:
+- '64.2'
+libiconv:
+- '1.15'
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  gmp:
+    max_pin: x
+  icu:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
 python:
 - '3.8'
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-igraph" %}
-{% set version = "0.7.1.post7" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,8 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/igraph/python-igraph/archive/release-0.7.tar.gz
-  sha256: 420b6c0446c70e849536f328e333cf489d6ad7f75a31e8259ef4512b56aa6d05
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 47e6bb48ec7dbfddbd89cf064a24b271783a1490fc688ebce17fbd652bcdab8e
 
 build:
   number: 0
@@ -17,19 +17,40 @@ build:
 
 requirements:
   build:
-    - pkg-config
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - pkg-config
+    - make
+    - automake
+    - autoconf
+    - bison
+    - flex
+    - libtool
   host:
-    - igraph 0.7.1
+    - gmp
+    - icu
+    - libiconv
+    - libxml2
+    - xz
+    - zlib
+    - texttable>=1.6.2
     - python
     - pip
-
   run:
-    - igraph 0.7.1
+    - gmp
+    - icu
+    - libiconv
+    - libxml2
+    - xz
+    - zlib
+    - texttable>=1.6.2
     - pycairo >=1.10,<2
     - python
 
 test:
+  source_files:
+    - tests
   files:
     - test_cairo.py
     - test_graphml.py
@@ -38,10 +59,8 @@ test:
     - igraph.app
     - igraph.drawing
     - igraph.remote
-    - igraph.test
-    - igraph.vendor
   commands:
-    - python -c 'from igraph.test import run_tests; run_tests()'
+    - python -m unittest
     - python test_cairo.py
     - python test_graphml.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libxml2
     - xz
     - zlib
-    - texttable>=1.6.2
+    - texttable >=1.6.2
     - python
     - pip
   run:
@@ -44,7 +44,7 @@ requirements:
     - libxml2
     - xz
     - zlib
-    - texttable>=1.6.2
+    - texttable >=1.6.2
     - pycairo >=1.10,<2
     - python
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0`
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Note that the `igraph` C core of `python-igraph` is now included in the `python-igraph` package itself. This is done so that the release schedule of `igraph`'s C core and its python interface no longer need to be in sync, making it easier to making new releases.

Version 0.8.0 also supports compilation under Windows. This PR is first to upgrade to 0.8.0 for other platforms, Windows support will follow later.