### PR TITLE
Add a patch to disable graph 70 in graph atlas tests

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -47,5 +47,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.7.____73_pypy.yaml
@@ -47,5 +47,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -47,5 +47,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -47,5 +47,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -47,5 +47,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sodre @vtraag
+* @sodre @vtraag @xylar

--- a/README.md
+++ b/README.md
@@ -333,4 +333,5 @@ Feedstock Maintainers
 
 * [@sodre](https://github.com/sodre/)
 * [@vtraag](https://github.com/vtraag/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
+++ b/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
@@ -1,0 +1,13 @@
+diff -ruN igraph-0.9.8/tests/test_atlas.py igraph-0.9.8-patch/tests/test_atlas.py
+--- igraph-0.9.8/tests/test_atlas.py	2021-10-28 22:10:52.000000000 +0200
++++ igraph-0.9.8-patch/tests/test_atlas.py	2021-12-02 08:55:14.649045828 +0100
+@@ -156,7 +156,8 @@
+ 
+ class GraphAtlasTests(unittest.TestCase, AtlasTestBase):
+     graphs = [Graph.Atlas(i) for i in range(1253)]
+-    skip_graphs = set([180])
++    # disabling graph 70 because of random failures
++    skip_graphs = set([70, 180])
+ 
+ 
+ class IsoclassTests(unittest.TestCase, AtlasTestBase):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ pypiname[0] }}/{{ pypiname }}/{{ pypiname }}-{{ version }}.tar.gz
   sha256: e7bad9f5f52e6dc3ccdaa3d02d8ec433d9ada704f7a83168915cfa0c4c226730
+  patches:
+    - 0001-skip-graph-70-in-graph-atlas-tests.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]
@@ -76,3 +78,4 @@ extra:
   recipe-maintainers:
     - sodre
     - vtraag
+    - xylar


### PR DESCRIPTION
This test seems to cause arbitrary failures.

Add xylar as a maintainer

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
