### PR TITLE
Correctly skip graph 70

### DIFF
--- a/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
+++ b/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
@@ -1,13 +1,34 @@
-diff -ruN igraph-0.9.8/tests/test_atlas.py igraph-0.9.8-patch/tests/test_atlas.py
---- igraph-0.9.8/tests/test_atlas.py	2021-10-28 22:10:52.000000000 +0200
-+++ igraph-0.9.8-patch/tests/test_atlas.py	2021-12-02 08:55:14.649045828 +0100
-@@ -156,7 +156,8 @@
+diff --git a/igraph-0.9.8/tests/test_atlas.py b/igraph-0.9.8/tests/test_atlas.py
+index 546a283..d8f2fdb 100644
+--- a/igraph-0.9.8/tests/test_atlas.py
++++ b/igraph-0.9.8/tests/test_atlas.py
+@@ -38,9 +38,6 @@ class AtlasTestBase:
+ 
+         try:
+             for idx, g in enumerate(self.__class__.graphs):
+-                if idx in self.__class__.skip_graphs:
+-                    # Skip this graph; it causes lots of problems and I don't know why
+-                    continue
+ 
+                 try:
+                     ec, eval = g.evcent(return_eigenvalue=True)
+@@ -156,14 +153,17 @@ class AtlasTestBase:
  
  class GraphAtlasTests(unittest.TestCase, AtlasTestBase):
      graphs = [Graph.Atlas(i) for i in range(1253)]
 -    skip_graphs = set([180])
-+    # disabling graph 70 because of random failures
-+    skip_graphs = set([70, 180])
  
++# Skip some problematic graphs
++GraphAtlasTests.graphs = [g for idx, g in enumerate(GraphAtlasTests.graphs) if idx not in set([180])]
  
  class IsoclassTests(unittest.TestCase, AtlasTestBase):
+     graphs = [Graph.Isoclass(3, i, directed=True) for i in range(16)] + [
+         Graph.Isoclass(4, i, directed=True) for i in range(218)
+     ]
+-    skip_graphs = set([136])
++
++# Skip some problematic graphs
++IsoclassTests.graphs = [g for idx, g in enumerate(IsoclassTests.graphs) if idx not in set([70, 136])]
+ 
+ 
+ def suite():

--- a/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
+++ b/recipe/0001-skip-graph-70-in-graph-atlas-tests.patch
@@ -12,14 +12,15 @@ index 546a283..d8f2fdb 100644
  
                  try:
                      ec, eval = g.evcent(return_eigenvalue=True)
-@@ -156,14 +153,17 @@ class AtlasTestBase:
+@@ -156,14 +153,18 @@ class AtlasTestBase:
  
  class GraphAtlasTests(unittest.TestCase, AtlasTestBase):
      graphs = [Graph.Atlas(i) for i in range(1253)]
 -    skip_graphs = set([180])
  
 +# Skip some problematic graphs
-+GraphAtlasTests.graphs = [g for idx, g in enumerate(GraphAtlasTests.graphs) if idx not in set([180])]
++GraphAtlasTests.graphs = [g for idx, g in enumerate(GraphAtlasTests.graphs) if idx not in set([70, 180])]
++print(len(GraphAtlasTests.graphs))
  
  class IsoclassTests(unittest.TestCase, AtlasTestBase):
      graphs = [Graph.Isoclass(3, i, directed=True) for i in range(16)] + [
@@ -28,7 +29,7 @@ index 546a283..d8f2fdb 100644
 -    skip_graphs = set([136])
 +
 +# Skip some problematic graphs
-+IsoclassTests.graphs = [g for idx, g in enumerate(IsoclassTests.graphs) if idx not in set([70, 136])]
++IsoclassTests.graphs = [g for idx, g in enumerate(IsoclassTests.graphs) if idx not in set([136])]
  
  
  def suite():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-skip-graph-70-in-graph-atlas-tests.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and vc<14]
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@xylar, I believe this should now correctly skip graph 70, as tried earlier in PR #53. Earlier, the graphs were not skipped for all tests. I've now simplified it so that the graphs are simply removed for all tests that are performed. Let's wait and see what the CI does.